### PR TITLE
Assign segments in a round robin fashion

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
@@ -28,7 +28,7 @@ import org.apache.druid.server.coordinator.duty.CompactionSegmentIterator;
 import org.apache.druid.server.coordinator.duty.CompactionSegmentSearchPolicy;
 import org.apache.druid.server.coordinator.duty.NewestSegmentFirstPolicy;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.DateTime;
@@ -82,7 +82,7 @@ public class NewestSegmentFirstPolicyBenchmark
   private int numCompactionTaskSlots;
 
   private Map<String, DataSourceCompactionConfig> compactionConfigs;
-  private Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources;
+  private Map<String, SegmentTimeline> dataSources;
 
   @Setup(Level.Trial)
   public void setup()

--- a/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
@@ -78,7 +78,7 @@ public class VersionedIntervalTimelineBenchmark
 
   private List<Interval> intervals;
   private List<DataSegment> segments;
-  private VersionedIntervalTimeline<String, DataSegment> timeline;
+  private SegmentTimeline timeline;
   private List<DataSegment> newSegments;
 
   @Setup
@@ -143,7 +143,7 @@ public class VersionedIntervalTimelineBenchmark
       nextMinorVersions.put(interval, (short) (numNonRootGenerations + 1));
     }
 
-    timeline = VersionedIntervalTimeline.forSegments(segments);
+    timeline = SegmentTimeline.forSegments(segments);
 
     newSegments = new ArrayList<>(200);
 
@@ -206,7 +206,7 @@ public class VersionedIntervalTimelineBenchmark
   @Benchmark
   public void benchAdd(Blackhole blackhole)
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(segments);
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segments);
     for (DataSegment newSegment : newSegments) {
       timeline.add(
           newSegment.getInterval(),
@@ -220,7 +220,7 @@ public class VersionedIntervalTimelineBenchmark
   public void benchRemove(Blackhole blackhole)
   {
     final List<DataSegment> segmentsCopy = new ArrayList<>(segments);
-    final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(segmentsCopy);
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segmentsCopy);
     final int numTests = (int) (segmentsCopy.size() * 0.1);
     for (int i = 0; i < numTests; i++) {
       final DataSegment segment = segmentsCopy.remove(ThreadLocalRandom.current().nextInt(segmentsCopy.size()));

--- a/core/src/main/java/org/apache/druid/timeline/Overshadowable.java
+++ b/core/src/main/java/org/apache/druid/timeline/Overshadowable.java
@@ -27,7 +27,7 @@ package org.apache.druid.timeline;
  * An Overshadowable overshadows another if its root partition range contains that of another
  * and has a higher minorVersion. For more details, check https://github.com/apache/druid/issues/7491.
  */
-public interface Overshadowable<T extends Overshadowable>
+public interface Overshadowable<T extends Overshadowable<T>>
 {
   /**
    * Returns true if this overshadowable overshadows the other.

--- a/core/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
@@ -17,26 +17,36 @@
  * under the License.
  */
 
-package org.apache.druid.server.coordinator.duty;
+package org.apache.druid.timeline;
 
-import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.timeline.SegmentTimeline;
-import org.joda.time.Interval;
-
-import java.util.List;
-import java.util.Map;
+import java.util.Comparator;
+import java.util.Iterator;
 
 /**
- * Segment searching policy used by {@link CompactSegments}.
+ * {@link VersionedIntervalTimeline} for {@link DataSegment} objects.
  */
-public interface CompactionSegmentSearchPolicy
+public class SegmentTimeline extends VersionedIntervalTimeline<String, DataSegment>
 {
-  /**
-   * Reset the current states of this policy. This method should be called whenever iterating starts.
-   */
-  CompactionSegmentIterator reset(
-      Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, SegmentTimeline> dataSources,
-      Map<String, List<Interval>> skipIntervals
-  );
+  public static SegmentTimeline forSegments(Iterable<DataSegment> segments)
+  {
+    return forSegments(segments.iterator());
+  }
+
+  public static SegmentTimeline forSegments(Iterator<DataSegment> segments)
+  {
+    final SegmentTimeline timeline = new SegmentTimeline();
+    VersionedIntervalTimeline.addSegments(timeline, segments);
+    return timeline;
+  }
+
+  public SegmentTimeline()
+  {
+    super(Comparator.naturalOrder());
+  }
+
+  public boolean isOvershadowed(DataSegment segment)
+  {
+    return isOvershadowed(segment.getInterval(), segment.getVersion(), segment);
+  }
+
 }

--- a/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -73,19 +73,6 @@ import java.util.stream.StreamSupport;
 public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshadowable<ObjectType>>
     implements TimelineLookup<VersionType, ObjectType>
 {
-  public static VersionedIntervalTimeline<String, DataSegment> forSegments(Iterable<DataSegment> segments)
-  {
-    return forSegments(segments.iterator());
-  }
-
-  public static VersionedIntervalTimeline<String, DataSegment> forSegments(Iterator<DataSegment> segments)
-  {
-    final VersionedIntervalTimeline<String, DataSegment> timeline =
-        new VersionedIntervalTimeline<>(Comparator.naturalOrder());
-    addSegments(timeline, segments);
-    return timeline;
-  }
-
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
   // Below timelines stores only *visible* timelineEntries
@@ -106,16 +93,16 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
   private final Comparator<? super VersionType> versionComparator;
 
   // Set this to true if the client needs to skip tombstones upon lookup (like the broker)
-  private boolean skipObjectsWithNoData = false;
+  private final boolean skipObjectsWithNoData;
 
   public VersionedIntervalTimeline(Comparator<? super VersionType> versionComparator)
   {
-    this.versionComparator = versionComparator;
+    this(versionComparator, false);
   }
 
   public VersionedIntervalTimeline(Comparator<? super VersionType> versionComparator, boolean skipObjectsWithNoData)
   {
-    this(versionComparator);
+    this.versionComparator = versionComparator;
     this.skipObjectsWithNoData = skipObjectsWithNoData;
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/SegmentTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/SegmentTimelineTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.timeline;
+
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class SegmentTimelineTest
+{
+
+  @Test
+  public void testIsOvershadowed()
+  {
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(
+        Arrays.asList(
+            createSegment("2022-01-01/2022-01-02", "v1", 0, 3),
+            createSegment("2022-01-01/2022-01-02", "v1", 1, 3),
+            createSegment("2022-01-01/2022-01-02", "v1", 2, 3),
+            createSegment("2022-01-02/2022-01-03", "v2", 0, 2),
+            createSegment("2022-01-02/2022-01-03", "v2", 1, 2)
+        )
+    );
+
+    Assert.assertFalse(
+        timeline.isOvershadowed(createSegment("2022-01-01/2022-01-02", "v1", 1, 3))
+    );
+    Assert.assertFalse(
+        timeline.isOvershadowed(createSegment("2022-01-01/2022-01-02", "v1", 2, 3))
+    );
+    Assert.assertFalse(
+        timeline.isOvershadowed(createSegment("2022-01-01/2022-01-02", "v1", 1, 4))
+    );
+    Assert.assertFalse(
+        timeline.isOvershadowed(createSegment("2022-01-01T00:00:00/2022-01-01T06:00:00", "v1", 1, 4))
+    );
+
+    Assert.assertTrue(
+        timeline.isOvershadowed(createSegment("2022-01-02/2022-01-03", "v1", 2, 4))
+    );
+    Assert.assertTrue(
+        timeline.isOvershadowed(createSegment("2022-01-02/2022-01-03", "v1", 0, 1))
+    );
+  }
+
+  private DataSegment createSegment(String interval, String version, int partitionNum, int totalNumPartitions)
+  {
+    return new DataSegment(
+        "wiki",
+        Intervals.of(interval),
+        version,
+        Collections.emptyMap(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        new NumberedShardSpec(partitionNum, totalNumPartitions),
+        0x9,
+        1L
+    );
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -175,7 +175,7 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.sql.calcite.rel.DruidQuery;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
@@ -957,7 +957,7 @@ public class ControllerImpl implements Controller
       if (dataSegments.isEmpty()) {
         return Optional.empty();
       } else {
-        return Optional.of(VersionedIntervalTimeline.forSegments(dataSegments));
+        return Optional.of(SegmentTimeline.forSegments(dataSegments));
       }
     };
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecSlicerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecSlicerTest.java
@@ -27,7 +27,7 @@ import org.apache.druid.msq.querykit.DataSegmentTimelineView;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,15 +79,14 @@ public class TableInputSpecSlicerTest extends InitializedNullHandlingTest
       BYTES_PER_SEGMENT
   );
 
-  private VersionedIntervalTimeline<String, DataSegment> timeline;
-  private DataSegmentTimelineView timelineView;
+  private SegmentTimeline timeline;
   private TableInputSpecSlicer slicer;
 
   @Before
   public void setUp()
   {
-    timeline = VersionedIntervalTimeline.forSegments(ImmutableList.of(SEGMENT1, SEGMENT2));
-    timelineView = (dataSource, intervals) -> {
+    timeline = SegmentTimeline.forSegments(ImmutableList.of(SEGMENT1, SEGMENT2));
+    DataSegmentTimelineView timelineView = (dataSource, intervals) -> {
       if (DATASOURCE.equals(dataSource)) {
         return Optional.of(timeline);
       } else {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopIngestionSpec.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopIngestionSpec.java
@@ -30,13 +30,12 @@ import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.IngestionSpec;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -199,8 +198,7 @@ public class HadoopIngestionSpec extends IngestionSpec<HadoopIOConfig, HadoopTun
         }
       }
 
-      final VersionedIntervalTimeline<String, DataSegment> timeline =
-          VersionedIntervalTimeline.forSegments(usedVisibleSegments);
+      final SegmentTimeline timeline = SegmentTimeline.forSegments(usedVisibleSegments);
       final List<WindowedDataSegment> windowedSegments = new ArrayList<>();
       for (Interval interval : ingestionSpecObj.getIntervals()) {
         final List<TimelineObjectHolder<String, DataSegment>> timeLineSegments = timeline.lookup(interval);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -74,7 +74,7 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.DateTime;
@@ -483,7 +483,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
       } else {
         // Use segment lock
         // Create a timeline to find latest segments only
-        final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(
+        final SegmentTimeline timeline = SegmentTimeline.forSegments(
             segments
         );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -96,8 +96,8 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.server.coordinator.duty.CompactSegments;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.apache.druid.timeline.partition.PartitionHolder;
 import org.joda.time.Duration;
@@ -735,7 +735,7 @@ public class CompactionTask extends AbstractBatchIndexTask
         segmentProvider.findSegments(toolbox.getTaskActionClient());
     segmentProvider.checkSegments(lockGranularityInUse, usedSegments);
     final Map<DataSegment, File> segmentFileMap = toolbox.fetchSegments(usedSegments);
-    final List<TimelineObjectHolder<String, DataSegment>> timelineSegments = VersionedIntervalTimeline
+    final List<TimelineObjectHolder<String, DataSegment>> timelineSegments = SegmentTimeline
         .forSegments(usedSegments)
         .lookup(segmentProvider.interval);
     return new NonnullPair<>(segmentFileMap, timelineSegments);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -71,8 +71,8 @@ import org.apache.druid.segment.realtime.firehose.ChatHandler;
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.joda.time.Interval;
@@ -267,7 +267,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
       // Find inputSegments overshadowed by pushedSegments
       final Set<DataSegment> allSegments = new HashSet<>(getTaskLockHelper().getLockedExistingSegments());
       allSegments.addAll(pushedSegments);
-      final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(allSegments);
+      final SegmentTimeline timeline = SegmentTimeline.forSegments(allSegments);
       final Set<DataSegment> oldSegments = FluentIterable.from(timeline.findFullyOvershadowed())
                                                          .transformAndConcat(TimelineObjectHolder::getObject)
                                                          .transform(PartitionChunk::getObject)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -56,8 +56,8 @@ import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.loading.SegmentCacheManager;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.apache.druid.timeline.partition.PartitionHolder;
 import org.apache.druid.utils.Streams;
@@ -509,7 +509,7 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
       }
     }
 
-    return VersionedIntervalTimeline.forSegments(usedSegments).lookup(interval);
+    return SegmentTimeline.forSegments(usedSegments).lookup(interval);
   }
 
   public static List<TimelineObjectHolder<String, DataSegment>> getTimelineForSegmentIds(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -50,7 +50,7 @@ import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.apache.druid.segment.realtime.firehose.LocalFirehoseFactory;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
@@ -241,7 +241,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         : getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", inputInterval, Segments.ONLY_VISIBLE);
     Assert.assertFalse(newSegments.isEmpty());
     allSegments.addAll(newSegments);
-    final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(allSegments);
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(allSegments);
 
     final Interval timelineInterval = inputInterval == null ? Intervals.ETERNITY : inputInterval;
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(
@@ -606,7 +606,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     final Collection<DataSegment> newSegments =
         getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE);
     Assert.assertTrue(newSegments.containsAll(oldSegments));
-    final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(newSegments);
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(newSegments);
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
     Assert.assertEquals(new HashSet<>(newSegments), visibles);
   }
@@ -663,8 +663,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     final Collection<DataSegment> afterAppendSegments =
         getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE);
     Assert.assertTrue(afterAppendSegments.containsAll(beforeAppendSegments));
-    final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline
-        .forSegments(afterAppendSegments);
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(afterAppendSegments);
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
     Assert.assertEquals(new HashSet<>(afterAppendSegments), visibles);
   }

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractITBatchIndexTest.java
@@ -42,8 +42,8 @@ import org.apache.druid.testing.clients.ClientInfoResourceTestClient;
 import org.apache.druid.testing.utils.ITRetryUtil;
 import org.apache.druid.testing.utils.SqlTestQueryHelper;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -359,7 +359,7 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
     if (waitForNewVersion) {
       ITRetryUtil.retryUntilTrue(
           () -> {
-            final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(
+            final SegmentTimeline timeline = SegmentTimeline.forSegments(
                 coordinator.getAvailableSegments(dataSourceName)
             );
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -42,8 +42,8 @@ import org.apache.druid.testing.clients.ClientInfoResourceTestClient;
 import org.apache.druid.testing.utils.ITRetryUtil;
 import org.apache.druid.testing.utils.SqlTestQueryHelper;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.testng.Assert;
 
 import java.io.IOException;
@@ -359,7 +359,7 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
     if (waitForNewVersion) {
       ITRetryUtil.retryUntilTrue(
           () -> {
-            final VersionedIntervalTimeline<String, DataSegment> timeline = VersionedIntervalTimeline.forSegments(
+            final SegmentTimeline timeline = SegmentTimeline.forSegments(
                 coordinator.getAvailableSegments(dataSourceName)
             );
 

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -50,8 +50,8 @@ import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.PartialShardSpec;
 import org.apache.druid.timeline.partition.PartitionChunk;
@@ -157,7 +157,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     return connector.retryWithHandle(
         handle -> {
           if (visibility == Segments.ONLY_VISIBLE) {
-            final VersionedIntervalTimeline<String, DataSegment> timeline =
+            final SegmentTimeline timeline =
                 getTimelineForIntervalsWithHandle(handle, dataSource, intervals);
             return timeline.findNonOvershadowedObjectsInInterval(Intervals.ETERNITY, Partitions.ONLY_COMPLETE);
           } else {
@@ -256,7 +256,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     return identifiers;
   }
 
-  private VersionedIntervalTimeline<String, DataSegment> getTimelineForIntervalsWithHandle(
+  private SegmentTimeline getTimelineForIntervalsWithHandle(
       final Handle handle,
       final String dataSource,
       final List<Interval> intervals
@@ -265,7 +265,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     try (final CloseableIterator<DataSegment> iterator =
              SqlSegmentsMetadataQuery.forHandle(handle, connector, dbTables, jsonMapper)
                                      .retrieveUsedSegments(dataSource, intervals)) {
-      return VersionedIntervalTimeline.forSegments(iterator);
+      return SegmentTimeline.forSegments(iterator);
     }
   }
 
@@ -323,7 +323,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     // Find which segments are used (i.e. not overshadowed).
     final Set<DataSegment> usedSegments = new HashSet<>();
     List<TimelineObjectHolder<String, DataSegment>> segmentHolders =
-        VersionedIntervalTimeline.forSegments(segments).lookupWithIncompletePartitions(Intervals.ETERNITY);
+        SegmentTimeline.forSegments(segments).lookupWithIncompletePartitions(Intervals.ETERNITY);
     for (TimelineObjectHolder<String, DataSegment> holder : segmentHolders) {
       for (PartitionChunk<DataSegment> chunk : holder.getObject()) {
         usedSegments.add(chunk.getObject());

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -97,11 +97,6 @@ public interface SegmentsMetadataManager
   Collection<ImmutableDruidDataSource> getImmutableDataSourcesWithAllUsedSegments();
 
   /**
-   * Returns a set of overshadowed segment ids.
-   */
-  Set<SegmentId> getOvershadowedSegments();
-
-  /**
    * Returns a snapshot of DruidDataSources and overshadowed segments
    */
   DataSourcesSnapshot getSnapshotOfDataSourcesWithAllUsedSegments();

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -93,7 +93,7 @@ public class SqlSegmentsMetadataQuery
    * You cannot assume that segments returned by this call are actually active. Because there is some delay between
    * new segment publishing and the marking-unused of older segments, it is possible that some segments returned
    * by this call are overshadowed by other segments. To check for this, use
-   * {@link org.apache.druid.timeline.VersionedIntervalTimeline#forSegments(Iterator)}.
+   * {@link org.apache.druid.timeline.SegmentTimeline#forSegments(Iterable)}.
    *
    * This call does not return any information about realtime segments.
    *

--- a/server/src/main/java/org/apache/druid/server/coordinator/CachingCostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CachingCostBalancerStrategy.java
@@ -42,15 +42,8 @@ public class CachingCostBalancerStrategy extends CostBalancerStrategy
   @Override
   protected double computeCost(DataSegment proposalSegment, ServerHolder server, boolean includeCurrentServer)
   {
-    final long proposalSegmentSize = proposalSegment.getSize();
-
-    // (optional) Don't include server if it is already serving segment
-    if (!includeCurrentServer && server.isServingSegment(proposalSegment)) {
-      return Double.POSITIVE_INFINITY;
-    }
-
-    // Don't calculate cost if the server doesn't have enough space or is loading the segment
-    if (proposalSegmentSize > server.getAvailableSize() || server.isLoadingSegment(proposalSegment)) {
+    // (optional) Don't include server if it cannot load the segment
+    if (!includeCurrentServer && !server.canLoadSegment(proposalSegment)) {
       return Double.POSITIVE_INFINITY;
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
@@ -317,15 +317,8 @@ public class CostBalancerStrategy implements BalancerStrategy
       final boolean includeCurrentServer
   )
   {
-    final long proposalSegmentSize = proposalSegment.getSize();
-
-    // (optional) Don't include server if it is already serving segment
-    if (!includeCurrentServer && server.isServingSegment(proposalSegment)) {
-      return Double.POSITIVE_INFINITY;
-    }
-
-    // Don't calculate cost if the server doesn't have enough space or is loading the segment
-    if (proposalSegmentSize > server.getAvailableSize() || server.isLoadingSegment(proposalSegment)) {
+    // (optional) Don't include server if it cannot load segment
+    if (!includeCurrentServer && !server.canLoadSegment(proposalSegment)) {
       return Double.POSITIVE_INFINITY;
     }
 
@@ -381,7 +374,7 @@ public class CostBalancerStrategy implements BalancerStrategy
 
     // Include current server only if specified
     return costPrioritizedServers.stream()
-                      .filter(pair -> includeCurrentServer || !pair.rhs.isServingSegment(proposalSegment))
+                      .filter(pair -> includeCurrentServer || pair.rhs.canLoadSegment(proposalSegment))
                       .map(pair -> pair.rhs).iterator();
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -395,6 +395,13 @@ public class DruidCoordinator
     return CoordinatorCompactionConfig.current(configManager);
   }
 
+  public void markSegmentsAsUnused(String datasource, Set<SegmentId> segmentIds)
+  {
+    log.debug("Marking [%d] segments of datasource [%s] as unused: %s", segmentIds.size(), datasource, segmentIds);
+    int updatedCount = segmentsMetadataManager.markSegmentsAsUnused(segmentIds);
+    log.info("Successfully marked [%d] segments of datasource [%s] as unused", updatedCount, datasource);
+  }
+
   public void markSegmentAsUnused(DataSegment segment)
   {
     log.debug("Marking segment[%s] as unused", segment.getId());

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -76,6 +76,7 @@ import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.initialization.jetty.ServiceUnavailableException;
 import org.apache.druid.server.lookup.cache.LookupCoordinatorManager;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -26,7 +26,7 @@ import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -128,7 +128,7 @@ public class DruidCoordinatorRuntimeParams
    * Creates and returns a "dataSource -> VersionedIntervalTimeline[version String, DataSegment]" map with "used"
    * segments.
    */
-  public Map<String, VersionedIntervalTimeline<String, DataSegment>> getUsedSegmentsTimelinesPerDataSource()
+  public Map<String, SegmentTimeline> getUsedSegmentsTimelinesPerDataSource()
   {
     Preconditions.checkState(dataSourcesSnapshot != null, "dataSourcesSnapshot or usedSegments must be set");
     return dataSourcesSnapshot.getUsedSegmentsTimelinesPerDataSource();
@@ -378,7 +378,7 @@ public class DruidCoordinatorRuntimeParams
     /** This method must be used in test code only. */
     @VisibleForTesting
     public Builder withUsedSegmentsTimelinesPerDataSourceInTest(
-        Map<String, VersionedIntervalTimeline<String, DataSegment>> usedSegmentsTimelinesPerDataSource
+        Map<String, SegmentTimeline> usedSegmentsTimelinesPerDataSource
     )
     {
       this.dataSourcesSnapshot = DataSourcesSnapshot.fromUsedSegmentsTimelines(

--- a/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
@@ -47,7 +47,9 @@ final class ReservoirSegmentSampler
         continue;
       }
 
-      for (DataSegment segment : server.getServer().iterateAllSegments()) {
+      List<DataSegment> loadingAndLoadedSegments = new ArrayList<>(server.getLoadingSegments());
+      loadingAndLoadedSegments.addAll(server.getServer().iterateAllSegments());
+      for (DataSegment segment : loadingAndLoadedSegments) {
         if (broadcastDatasources.contains(segment.getDataSource())) {
           // we don't need to rebalance segments that were assigned via broadcast rules
           continue;

--- a/server/src/main/java/org/apache/druid/server/coordinator/RoundRobinServerSelector.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/RoundRobinServerSelector.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator;
+
+import org.apache.druid.timeline.DataSegment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Provides iterators over servers for a given tier that can load a specified
+ * segment.
+ * <p>
+ * Once a selector is initialized with a {@link DruidCluster}, an iterator
+ * returned by {@link #getServersInTierToLoadSegment(String, DataSegment)}
+ * iterates over the servers in a tier in a round robin fashion. The next
+ * invocation of this method picks up where the last iterator had left off.
+ * <p>
+ * This class is not thread-safe and must be used from a single thread.
+ */
+public class RoundRobinServerSelector
+{
+  private final Map<String, CircularServerList> tierToServers = new HashMap<>();
+
+  public RoundRobinServerSelector(DruidCluster cluster)
+  {
+    cluster.getHistoricals().forEach(
+        (tier, servers) -> tierToServers.put(tier, new CircularServerList(servers))
+    );
+  }
+
+  /**
+   * Returns an iterator over the servers in this tier which are eligible to
+   * load the given segment.
+   */
+  public Iterator<ServerHolder> getServersInTierToLoadSegment(String tier, DataSegment segment)
+  {
+    final CircularServerList iterator = tierToServers.get(tier);
+    if (iterator == null) {
+      return Collections.emptyIterator();
+    }
+
+    return new EligibleServerIterator(segment, iterator);
+  }
+
+  /**
+   * Iterator over servers in a tier that are eligible to load a given segment.
+   */
+  private static class EligibleServerIterator implements Iterator<ServerHolder>
+  {
+    final CircularServerList delegate;
+    final DataSegment segment;
+
+    ServerHolder nextEligible;
+    int remainingIterations;
+
+    EligibleServerIterator(DataSegment segment, CircularServerList delegate)
+    {
+      this.delegate = delegate;
+      this.segment = segment;
+      this.remainingIterations = delegate.servers.size();
+      nextEligible = search();
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+      return nextEligible != null;
+    }
+
+    @Override
+    public ServerHolder next()
+    {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      ServerHolder previous = nextEligible;
+      delegate.advanceCursor();
+      nextEligible = search();
+      return previous;
+    }
+
+    ServerHolder search()
+    {
+      while (remainingIterations-- > 0) {
+        ServerHolder nextServer = delegate.peekNext();
+        if (nextServer.canLoadSegment(segment)) {
+          return nextServer;
+        } else {
+          delegate.advanceCursor();
+        }
+      }
+
+      return null;
+    }
+  }
+
+  /**
+   * Circular list over all servers in a tier. A single instance of this is
+   * maintained for each tier.
+   */
+  private static class CircularServerList
+  {
+    final List<ServerHolder> servers = new ArrayList<>();
+    int currentPosition;
+
+    CircularServerList(Set<ServerHolder> servers)
+    {
+      this.servers.addAll(servers);
+      //Collections.shuffle(this.servers);
+    }
+
+    void advanceCursor()
+    {
+      if (++currentPosition >= servers.size()) {
+        currentPosition = 0;
+      }
+    }
+
+    ServerHolder peekNext()
+    {
+      int nextPosition = currentPosition < servers.size() ? currentPosition : 0;
+      return servers.get(nextPosition);
+    }
+  }
+
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/SegmentLoader.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/SegmentLoader.java
@@ -46,6 +46,7 @@ public class SegmentLoader
   private final CoordinatorStats stats = new CoordinatorStats();
   private final SegmentReplicantLookup replicantLookup;
   private final ReplicationThrottler replicationThrottler;
+  private final RoundRobinServerSelector serverSelector;
   private final BalancerStrategy strategy;
 
   private final Set<String> emptyTiers = new HashSet<>();
@@ -63,6 +64,7 @@ public class SegmentLoader
     this.stateManager = stateManager;
     this.replicantLookup = replicantLookup;
     this.replicationThrottler = replicationThrottler;
+    this.serverSelector = new RoundRobinServerSelector(cluster);
   }
 
   public CoordinatorStats getStats()
@@ -392,7 +394,7 @@ public class SegmentLoader
     }
 
     final Iterator<ServerHolder> serverIterator =
-        strategy.findNewSegmentHomeReplicator(segment, eligibleServers);
+        serverSelector.getServersInTierToLoadSegment(tier, segment);
     if (!serverIterator.hasNext()) {
       log.warn("No candidate server to load replica of segment [%s]", segment.getId());
       return 0;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/BalanceSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/BalanceSegments.java
@@ -152,11 +152,12 @@ public class BalanceSegments implements CoordinatorDuty
 
     int numSegments = 0;
     for (ServerHolder sourceHolder : servers) {
-      numSegments += sourceHolder.getServer().getNumSegments();
+      numSegments += sourceHolder.getServer().getNumSegments()
+                     + sourceHolder.getPeon().getNumberOfSegmentsInQueue();
     }
 
     if (numSegments == 0) {
-      log.info("Skipping balance for tier [%s] as there are no served segments.", tier);
+      log.info("Skipping balance for tier [%s] as there are no loaded or loading segments.", tier);
       // suppress emit zero stats
       return;
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -45,7 +45,7 @@ import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -127,7 +127,7 @@ public class CompactSegments implements CoordinatorCustomDuty
     final CoordinatorStats stats = new CoordinatorStats();
     List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
     if (dynamicConfig.getMaxCompactionTaskSlots() > 0) {
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources =
+      Map<String, SegmentTimeline> dataSources =
           params.getUsedSegmentsTimelinesPerDataSource();
       if (compactionConfigList != null && !compactionConfigList.isEmpty()) {
         Map<String, DataSourceCompactionConfig> compactionConfigs = compactionConfigList

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -151,6 +151,13 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
             emitMetricWithDimension("coordinator/time", count, DruidMetrics.DUTY, duty)
     );
 
+    // Emit temp stats
+    stats.forEachDutyStat(
+        "adhoc",
+        (duty, count) ->
+            emitMetricWithDimension("coordinator/adhoc/time", count, DruidMetrics.DUTY, duty)
+    );
+
     return params;
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -48,6 +48,7 @@ import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedPartitionChunk;
@@ -103,7 +104,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
   NewestSegmentFirstIterator(
       ObjectMapper objectMapper,
       Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources,
+      Map<String, SegmentTimeline> dataSources,
       Map<String, List<Interval>> skipIntervals
   )
   {
@@ -111,7 +112,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     this.compactionConfigs = compactionConfigs;
     this.timelineIterators = Maps.newHashMapWithExpectedSize(dataSources.size());
 
-    dataSources.forEach((String dataSource, VersionedIntervalTimeline<String, DataSegment> timeline) -> {
+    dataSources.forEach((String dataSource, SegmentTimeline timeline) -> {
       final DataSourceCompactionConfig config = compactionConfigs.get(dataSource);
       Granularity configuredSegmentGranularity = null;
       if (config != null && !timeline.isEmpty()) {
@@ -121,7 +122,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           Map<Interval, Set<DataSegment>> intervalToPartitionMap = new HashMap<>();
           configuredSegmentGranularity = config.getGranularitySpec().getSegmentGranularity();
           // Create a new timeline to hold segments in the new configured segment granularity
-          VersionedIntervalTimeline<String, DataSegment> timelineWithConfiguredSegmentGranularity = new VersionedIntervalTimeline<>(Comparator.naturalOrder());
+          SegmentTimeline timelineWithConfiguredSegmentGranularity = new SegmentTimeline();
           Set<DataSegment> segments = timeline.findNonOvershadowedObjectsInInterval(Intervals.ETERNITY, Partitions.ONLY_COMPLETE);
           for (DataSegment segment : segments) {
             // Convert original segmentGranularity to new granularities bucket by configuredSegmentGranularity

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicy.java
@@ -21,8 +21,7 @@ package org.apache.druid.server.coordinator.duty;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
 
 import java.util.List;
@@ -43,7 +42,7 @@ public class NewestSegmentFirstPolicy implements CompactionSegmentSearchPolicy
   @Override
   public CompactionSegmentIterator reset(
       Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources,
+      Map<String, SegmentTimeline> dataSources,
       Map<String, List<Interval>> skipIntervals
   )
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -77,7 +77,7 @@ public class RunRules implements CoordinatorDuty
     // eventually will be unloaded from Historical servers. Segments overshadowed by *served* used segments are marked
     // as unused in MarkAsUnusedOvershadowedSegments, and then eventually Coordinator sends commands to Historical nodes
     // to unload such segments in UnloadUnusedSegments.
-    Set<SegmentId> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
+    Set<DataSegment> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
 
     // Run through all matched rules for used segments
     DateTime now = DateTimes.nowUtc();
@@ -114,7 +114,7 @@ public class RunRules implements CoordinatorDuty
         params.getBalancerStrategy()
     );
     for (DataSegment segment : params.getUsedSegments()) {
-      if (overshadowed.contains(segment.getId())) {
+      if (overshadowed.contains(segment)) {
         // Skipping overshadowed segments
         continue;
       }

--- a/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
@@ -182,10 +182,10 @@ public class MetadataResource
     final Stream<DataSegment> usedSegments = dataSourcesWithUsedSegments
         .stream()
         .flatMap(t -> t.getSegments().stream());
-    final Set<SegmentId> overshadowedSegments = dataSourcesSnapshot.getOvershadowedSegments();
+    final Set<DataSegment> overshadowedSegments = dataSourcesSnapshot.getOvershadowedSegments();
 
     final Stream<SegmentWithOvershadowedStatus> usedSegmentsWithOvershadowedStatus = usedSegments
-        .map(segment -> new SegmentWithOvershadowedStatus(segment, overshadowedSegments.contains(segment.getId())));
+        .map(segment -> new SegmentWithOvershadowedStatus(segment, overshadowedSegments.contains(segment)));
 
     final Function<SegmentWithOvershadowedStatus, Iterable<ResourceAction>> raGenerator = segment -> Collections
         .singletonList(AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(segment.getDataSegment().getDataSource()));

--- a/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
@@ -321,6 +321,8 @@ public class CuratorDruidCoordinatorTest extends CuratorTestBase
     EasyMock.expect(coordinatorRuntimeParams.getDataSourcesSnapshot()).andReturn(dataSourcesSnapshot).anyTimes();
     EasyMock.expect(coordinatorRuntimeParams.getCoordinatorDynamicConfig())
             .andReturn(CoordinatorDynamicConfig.builder().build()).anyTimes();
+    EasyMock.expect(coordinatorRuntimeParams.getDruidCluster())
+            .andReturn(DruidClusterBuilder.newBuilder().build()).anyTimes();
     EasyMock.replay(segmentsMetadataManager, coordinatorRuntimeParams);
 
     EasyMock.expect(dataSourcesSnapshot.getDataSource(EasyMock.anyString())).andReturn(druidDataSource).anyTimes();

--- a/server/src/test/java/org/apache/druid/server/coordinator/ReservoirSegmentSamplerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/ReservoirSegmentSamplerTest.java
@@ -19,173 +19,66 @@
 
 package org.apache.druid.server.coordinator;
 
-import com.google.common.collect.Lists;
-import org.apache.druid.client.ImmutableDruidServer;
-import org.apache.druid.client.ImmutableDruidServerTests;
-import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.easymock.EasyMock;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ReservoirSegmentSamplerTest
 {
-  private ImmutableDruidServer druidServer1;
-  private ImmutableDruidServer druidServer2;
-  private ImmutableDruidServer druidServer3;
-  private ImmutableDruidServer druidServer4;
 
-  private ServerHolder holder1;
-  private ServerHolder holder2;
-  private ServerHolder holder3;
-  private ServerHolder holder4;
-
-  private DataSegment segment1;
-  private DataSegment segment2;
-  private DataSegment segment3;
-  private DataSegment segment4;
-  List<DataSegment> segments1;
-  List<DataSegment> segments2;
-  List<DataSegment> segments3;
-  List<DataSegment> segments4;
-  List<DataSegment> segments;
+  /**
+   * num segments = 10 x 100 days
+   */
+  private final List<DataSegment> segments =
+      CreateDataSegments.ofDatasource("wiki")
+                        .forIntervals(100, Granularities.DAY)
+                        .startingAt("2022-01-01")
+                        .withNumPartitions(10)
+                        .eachOfSizeInMb(100);
 
   @Before
   public void setUp()
   {
-    druidServer1 = EasyMock.createMock(ImmutableDruidServer.class);
-    druidServer2 = EasyMock.createMock(ImmutableDruidServer.class);
-    druidServer3 = EasyMock.createMock(ImmutableDruidServer.class);
-    druidServer4 = EasyMock.createMock(ImmutableDruidServer.class);
-    holder1 = EasyMock.createMock(ServerHolder.class);
-    holder2 = EasyMock.createMock(ServerHolder.class);
-    holder3 = EasyMock.createMock(ServerHolder.class);
-    holder4 = EasyMock.createMock(ServerHolder.class);
-    segment1 = EasyMock.createMock(DataSegment.class);
-    segment2 = EasyMock.createMock(DataSegment.class);
-    segment3 = EasyMock.createMock(DataSegment.class);
-    segment4 = EasyMock.createMock(DataSegment.class);
-
-    DateTime start1 = DateTimes.of("2012-01-01");
-    DateTime start2 = DateTimes.of("2012-02-01");
-    DateTime version = DateTimes.of("2012-03-01");
-    segment1 = new DataSegment(
-        "datasource1",
-        new Interval(start1, start1.plusHours(1)),
-        version.toString(),
-        new HashMap<>(),
-        new ArrayList<>(),
-        new ArrayList<>(),
-        NoneShardSpec.instance(),
-        0,
-        11L
-    );
-    segment2 = new DataSegment(
-        "datasource1",
-        new Interval(start2, start2.plusHours(1)),
-        version.toString(),
-        new HashMap<>(),
-        new ArrayList<>(),
-        new ArrayList<>(),
-        NoneShardSpec.instance(),
-        0,
-        7L
-    );
-    segment3 = new DataSegment(
-        "datasource2",
-        new Interval(start1, start1.plusHours(1)),
-        version.toString(),
-        new HashMap<>(),
-        new ArrayList<>(),
-        new ArrayList<>(),
-        NoneShardSpec.instance(),
-        0,
-        4L
-    );
-    segment4 = new DataSegment(
-        "datasource2",
-        new Interval(start2, start2.plusHours(1)),
-        version.toString(),
-        new HashMap<>(),
-        new ArrayList<>(),
-        new ArrayList<>(),
-        NoneShardSpec.instance(),
-        0,
-        8L
-    );
-
-    segments = Lists.newArrayList(segment1, segment2, segment3, segment4);
-
-    segments1 = Collections.singletonList(segment1);
-    segments2 = Collections.singletonList(segment2);
-    segments3 = Collections.singletonList(segment3);
-    segments4 = Collections.singletonList(segment4);
   }
 
-  //checks if every segment is selected at least once out of 5000 trials
+  //checks if every segment is selected at least once out of 50 trials
   @Test
-  public void getRandomBalancerSegmentHolderTest()
+  public void testEverySegmentGetsPickedAtleastOnce()
   {
-    int iterations = 5000;
+    int iterations = 50;
 
-    EasyMock.expect(druidServer1.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer1, segments1);
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer2, segments2);
-    EasyMock.replay(druidServer2);
-
-    EasyMock.expect(druidServer3.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer3, segments3);
-    EasyMock.replay(druidServer3);
-
-    EasyMock.expect(druidServer4.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer4, segments4);
-    EasyMock.replay(druidServer4);
-
-    // Have to use anyTimes() because the number of times a segment on a given server is chosen is indetermistic.
-    EasyMock.expect(holder1.getServer()).andReturn(druidServer1).anyTimes();
-    EasyMock.replay(holder1);
-    EasyMock.expect(holder2.getServer()).andReturn(druidServer2).anyTimes();
-    EasyMock.replay(holder2);
-    EasyMock.expect(holder3.getServer()).andReturn(druidServer3).anyTimes();
-    EasyMock.replay(holder3);
-    EasyMock.expect(holder4.getServer()).andReturn(druidServer4).anyTimes();
-    EasyMock.replay(holder4);
-
-    List<ServerHolder> holderList = new ArrayList<>();
-    holderList.add(holder1);
-    holderList.add(holder2);
-    holderList.add(holder3);
-    holderList.add(holder4);
-
+    final List<ServerHolder> servers = Arrays.asList(
+        createHistorical("server1", segments.get(0)),
+        createHistorical("server2", segments.get(1)),
+        createHistorical("server3", segments.get(2)),
+        createHistorical("server4", segments.get(3))
+    );
     Map<DataSegment, Integer> segmentCountMap = new HashMap<>();
     for (int i = 0; i < iterations; i++) {
       // due to the pseudo-randomness of this method, we may not select a segment every single time no matter what.
-      segmentCountMap.put(
-          ReservoirSegmentSampler.getRandomBalancerSegmentHolders(holderList, Collections.emptySet(), 1).get(0).getSegment(),
-          1
+      segmentCountMap.compute(
+          ReservoirSegmentSampler
+              .getRandomBalancerSegmentHolders(servers, Collections.emptySet(), 1)
+              .get(0).getSegment(),
+          (segment, count) -> count == null ? 1 : count + 1
       );
     }
 
-    for (DataSegment segment : segments) {
-      Assert.assertEquals(new Integer(1), segmentCountMap.get(segment));
-    }
-
-    EasyMock.verify(druidServer1, druidServer2, druidServer3, druidServer4);
-    EasyMock.verify(holder1, holder2, holder3, holder4);
+    // Verify that each segment has been chosen at least once
+    Assert.assertEquals(4, segmentCountMap.size());
   }
 
   /**
@@ -195,56 +88,162 @@ public class ReservoirSegmentSamplerTest
   @Test
   public void getRandomBalancerSegmentHolderTestSegmentsToConsiderLimit()
   {
-    int iterations = 5000;
+    int iterations = 50;
 
-    EasyMock.expect(druidServer1.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer1, segments1);
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer2, segments2);
-    EasyMock.replay(druidServer2);
-
-    EasyMock.expect(druidServer3.getType()).andReturn(ServerType.HISTORICAL).times(iterations);
-    ImmutableDruidServerTests.expectSegments(druidServer3, segments3);
-    EasyMock.replay(druidServer3);
-
-    ImmutableDruidServerTests.expectSegments(druidServer4, segments4);
-    EasyMock.replay(druidServer4);
-
-    // Have to use anyTimes() because the number of times a segment on a given server is chosen is indetermistic.
-    EasyMock.expect(holder1.getServer()).andReturn(druidServer1).anyTimes();
-    EasyMock.replay(holder1);
-    EasyMock.expect(holder2.getServer()).andReturn(druidServer2).anyTimes();
-    EasyMock.replay(holder2);
-    EasyMock.expect(holder3.getServer()).andReturn(druidServer3).anyTimes();
-    EasyMock.replay(holder3);
-    // We only run getServer() each time we calculate the limit on segments to consider. Always 5k
-    EasyMock.expect(holder4.getServer()).andReturn(druidServer4).times(5000);
-    EasyMock.replay(holder4);
-
-    List<ServerHolder> holderList = new ArrayList<>();
-    holderList.add(holder1);
-    holderList.add(holder2);
-    holderList.add(holder3);
-    holderList.add(holder4);
+    final DataSegment excludedSegment = segments.get(3);
+    final List<ServerHolder> servers = Arrays.asList(
+        createHistorical("server1", segments.get(0)),
+        createHistorical("server2", segments.get(1)),
+        createHistorical("server3", segments.get(2)),
+        createHistorical("server4", excludedSegment)
+    );
 
     Map<DataSegment, Integer> segmentCountMap = new HashMap<>();
+
+    final double percentOfSegmentsToConsider = 75.0;
     for (int i = 0; i < iterations; i++) {
-      segmentCountMap.put(
-          ReservoirSegmentSampler.getRandomBalancerSegmentHolder(holderList, Collections.emptySet(), 75).getSegment(), 1
+      segmentCountMap.compute(
+          ReservoirSegmentSampler
+              .getRandomBalancerSegmentHolder(servers, Collections.emptySet(), percentOfSegmentsToConsider)
+              .getSegment(),
+          (segment, count) -> count == null ? 1 : count + 1
       );
     }
 
-    for (DataSegment segment : segments) {
-      if (!segment.equals(segment4)) {
-        Assert.assertEquals(new Integer(1), segmentCountMap.get(segment));
-      } else {
-        Assert.assertNull(segmentCountMap.get(segment));
+    // Verify that the segment on server4 is never chosen because of limit
+    Assert.assertFalse(segmentCountMap.containsKey(excludedSegment));
+    Assert.assertEquals(3, segmentCountMap.size());
+  }
+
+  @Test
+  public void testLoadingSegmentGetsPicked()
+  {
+    final List<DataSegment> loadedSegments = Arrays.asList(segments.get(0), segments.get(1));
+    final List<DataSegment> loadingSegments = Arrays.asList(segments.get(2), segments.get(3));
+
+    final ServerHolder server1 = createHistorical("server1", loadedSegments.get(0));
+    server1.getPeon().loadSegment(loadingSegments.get(0), SegmentAction.LOAD, null);
+
+    final ServerHolder server2 = createHistorical("server2", loadedSegments.get(1));
+    server2.getPeon().loadSegment(loadingSegments.get(1), SegmentAction.LOAD, null);
+
+    Set<DataSegment> pickedSegments = ReservoirSegmentSampler
+        .getRandomBalancerSegmentHolders(Arrays.asList(server1, server2), Collections.emptySet(), 10)
+        .stream().map(BalancerSegmentHolder::getSegment).collect(Collectors.toSet());
+
+    // Verify that both loaded and loading segments are picked
+    Assert.assertTrue(pickedSegments.containsAll(loadedSegments));
+    Assert.assertTrue(pickedSegments.containsAll(loadingSegments));
+  }
+
+  @Test
+  public void testSegmentsOnBrokersAreIgnored()
+  {
+    final ServerHolder historical = createHistorical("hist1", segments.get(0), segments.get(1));
+
+    final ServerHolder broker = new ServerHolder(
+        new DruidServer("broker1", "broker1", null, 1000, ServerType.BROKER, null, 1)
+            .addDataSegment(segments.get(2))
+            .addDataSegment(segments.get(3))
+            .toImmutableDruidServer(),
+        new LoadQueuePeonTester()
+    );
+
+    // Try to pick all the segments on the servers
+    List<BalancerSegmentHolder> pickedSegments = ReservoirSegmentSampler.getRandomBalancerSegmentHolders(
+        Arrays.asList(historical, broker),
+        Collections.emptySet(),
+        10
+    );
+
+    // Verify that only the segments on the historical are picked
+    Assert.assertEquals(2, pickedSegments.size());
+    for (BalancerSegmentHolder holder : pickedSegments) {
+      Assert.assertEquals(historical, holder.getFromServer());
+    }
+  }
+
+  @Test
+  public void testBroadcastSegmentsAreIgnored()
+  {
+    // num segments = 1 x 4 days
+    final String broadcastDatasource = "ds_broadcast";
+    final List<DataSegment> broadcastSegments
+        = CreateDataSegments.ofDatasource(broadcastDatasource)
+                            .forIntervals(4, Granularities.DAY)
+                            .startingAt("2022-01-01")
+                            .withNumPartitions(1)
+                            .eachOfSizeInMb(100);
+
+    final List<ServerHolder> servers = Arrays.asList(
+        createHistorical("server1", broadcastSegments.toArray(new DataSegment[0])),
+        createHistorical("server2", segments.get(0), segments.get(1))
+    );
+
+    // Try to pick all the segments on the servers
+    List<BalancerSegmentHolder> pickedSegments = ReservoirSegmentSampler
+        .getRandomBalancerSegmentHolders(servers, Collections.singleton(broadcastDatasource), 10);
+
+    // Verify that none of the broadcast segments are picked
+    Assert.assertEquals(2, pickedSegments.size());
+    for (BalancerSegmentHolder holder : pickedSegments) {
+      Assert.assertNotEquals(broadcastDatasource, holder.getSegment().getDataSource());
+    }
+  }
+
+  @Test(timeout = 60_000)
+  public void testNumberOfIterationsToCycleThroughAllSegments()
+  {
+    // The number of runs required for each sample percentage
+    // remains more or less fixed, even with a larger number of segments
+    for (int i = 0; i < 10; ++i) {
+      Assert.assertEquals(1, countMinRunsWithSamplePercent(100));
+      Assert.assertTrue(countMinRunsWithSamplePercent(50) < 20);
+      Assert.assertTrue(countMinRunsWithSamplePercent(10) < 100);
+      Assert.assertTrue(countMinRunsWithSamplePercent(5) < 200);
+      Assert.assertTrue(countMinRunsWithSamplePercent(1) < 1000);
+    }
+  }
+
+  /**
+   * Returns the minimum number of iterations of the reservoir sampling required
+   * to pick each segment atleast once.
+   * <p>
+   * {@code k = sampleSize = totalNumSegments * samplePercentage}
+   */
+  private int countMinRunsWithSamplePercent(double samplePercentage)
+  {
+    final int numSegments = segments.size();
+    final List<ServerHolder> servers = Arrays.asList(
+        createHistorical("server1", segments.subList(0, numSegments / 2).toArray(new DataSegment[0])),
+        createHistorical("server2", segments.subList(numSegments / 2, numSegments).toArray(new DataSegment[0]))
+    );
+
+    final Set<DataSegment> pickedSegments = new HashSet<>();
+
+    int sampleSize = (int) (numSegments * samplePercentage / 100.0);
+
+    int numIterations = 1;
+    for (; numIterations < 10000; ++numIterations) {
+      ReservoirSegmentSampler
+          .getRandomBalancerSegmentHolders(servers, Collections.emptySet(), sampleSize)
+          .forEach(holder -> pickedSegments.add(holder.getSegment()));
+
+      if (pickedSegments.size() >= numSegments) {
+        break;
       }
     }
 
-    EasyMock.verify(druidServer1, druidServer2, druidServer3, druidServer4);
-    EasyMock.verify(holder1, holder2, holder3, holder4);
+    return numIterations;
+  }
+
+  private ServerHolder createHistorical(String serverName, DataSegment... loadedSegments)
+  {
+    final DruidServer server =
+        new DruidServer(serverName, serverName, null, 100000, ServerType.HISTORICAL, "normal", 1);
+    for (DataSegment segment : loadedSegments) {
+      server.addDataSegment(segment);
+    }
+    return new ServerHolder(server.toImmutableDruidServer(), new LoadQueuePeonTester());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/RoundRobinServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/RoundRobinServerSelectorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator;
+
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.IndexIO;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+public class RoundRobinServerSelectorTest
+{
+  private static final String TIER = "normal";
+
+  private final DataSegment segment = new DataSegment(
+      "wiki",
+      Intervals.of("2022-01-01/2022-01-02"),
+      "1",
+      Collections.emptyMap(),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      new NumberedShardSpec(1, 10),
+      IndexIO.CURRENT_VERSION_ID,
+      100
+  );
+
+  @Test
+  public void testSingleIterator()
+  {
+    final ServerHolder serverXL = createHistorical("serverXL", 1000);
+    final ServerHolder serverL = createHistorical("serverXL", 900);
+    final ServerHolder serverM = createHistorical("serverXL", 800);
+
+    // This server is too small to house the segment
+    final ServerHolder serverXS = createHistorical("serverXL", 10);
+
+    DruidCluster cluster = DruidClusterBuilder
+        .newBuilder()
+        .addTier(TIER, serverXL, serverM, serverXS, serverL)
+        .build();
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+
+    // Verify that only eligible servers are returned in order of available size
+    Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
+
+    Assert.assertTrue(pickedServers.hasNext());
+    Assert.assertEquals(serverXL, pickedServers.next());
+    Assert.assertEquals(serverL, pickedServers.next());
+    Assert.assertEquals(serverM, pickedServers.next());
+
+    Assert.assertFalse(pickedServers.hasNext());
+  }
+
+  @Test
+  public void testNextIteratorContinuesFromSamePosition()
+  {
+    final ServerHolder serverXL = createHistorical("serverXL", 1000);
+    final ServerHolder serverL = createHistorical("serverXL", 900);
+    final ServerHolder serverM = createHistorical("serverXL", 800);
+
+    // This server is too small to house the segment
+    final ServerHolder serverXS = createHistorical("serverXL", 10);
+
+    DruidCluster cluster = DruidClusterBuilder
+        .newBuilder()
+        .addTier(TIER, serverXL, serverM, serverXS, serverL)
+        .build();
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+
+    // Verify that only eligible servers are returned in order of available size
+    Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
+    Assert.assertTrue(pickedServers.hasNext());
+    Assert.assertEquals(serverXL, pickedServers.next());
+
+    // Second iterator starts from previous position but resets allowed number of iterations
+    pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
+    Assert.assertTrue(pickedServers.hasNext());
+
+    Assert.assertEquals(serverL, pickedServers.next());
+    Assert.assertEquals(serverM, pickedServers.next());
+    Assert.assertEquals(serverXL, pickedServers.next());
+
+    Assert.assertFalse(pickedServers.hasNext());
+  }
+
+  @Test
+  public void testNoServersInTier()
+  {
+    DruidCluster cluster = DruidClusterBuilder
+        .newBuilder()
+        .addTier(TIER)
+        .build();
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+
+    Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);
+    Assert.assertFalse(eligibleServers.hasNext());
+  }
+
+  @Test
+  public void testNoEligibleServerInTier()
+  {
+    DruidCluster cluster = DruidClusterBuilder
+        .newBuilder()
+        .addTier(
+            TIER,
+            createHistorical("server1", 40),
+            createHistorical("server2", 30),
+            createHistorical("server3", 10),
+            createHistorical("server4", 20)
+        )
+        .build();
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+
+    // Verify that only eligible servers are returned in order of available size
+    Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);
+    Assert.assertFalse(eligibleServers.hasNext());
+  }
+
+  private ServerHolder createHistorical(String name, long size)
+  {
+    return new ServerHolder(
+        new DruidServer(name, name, null, size, ServerType.HISTORICAL, TIER, 1).toImmutableDruidServer(),
+        new LoadQueuePeonTester()
+    );
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -86,6 +86,7 @@ import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
 import org.apache.druid.server.coordinator.UserCompactionTaskTransformConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
@@ -176,7 +177,7 @@ public class CompactSegmentsTest
   private final PartitionsSpec partitionsSpec;
   private final BiFunction<Integer, Integer, ShardSpec> shardSpecFactory;
 
-  private Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources;
+  private Map<String, SegmentTimeline> dataSources;
   Map<String, List<DataSegment>> datasourceToSegments = new HashMap<>();
 
   public CompactSegmentsTest(PartitionsSpec partitionsSpec, BiFunction<Integer, Integer, ShardSpec> shardSpecFactory)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
@@ -118,8 +118,7 @@ public class MarkAsUnusedOvershadowedSegmentsTest
             .andReturn(ImmutableSet.of(segmentV1, segmentV2))
             .anyTimes();
     EasyMock.expect(druidDataSource.getName()).andReturn("test").anyTimes();
-    coordinator.markSegmentAsUnused(segmentV1);
-    coordinator.markSegmentAsUnused(segmentV0);
+    coordinator.markSegmentsAsUnused("test", ImmutableSet.of(segmentV1.getId(), segmentV0.getId()));
     EasyMock.expectLastCall();
     EasyMock.replay(mockPeon, coordinator, druidServer, druidDataSource);
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicyTest.java
@@ -55,7 +55,7 @@ import org.apache.druid.server.coordinator.UserCompactionTaskTransformConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.assertj.core.api.Assertions;
@@ -315,7 +315,7 @@ public class NewestSegmentFirstPolicyTest
   public void testClearSegmentsToCompactWhenSkippingSegments()
   {
     final long inputSegmentSizeBytes = 800000;
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-03T00:00:00/2017-12-04T00:00:00"),
             new Period("P1D"),
@@ -359,7 +359,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfFirstSegmentIsInSkipOffset()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-02T14:00:00/2017-12-03T00:00:00"),
             new Period("PT5H"),
@@ -380,7 +380,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfFirstSegmentOverlapsSkipOffset()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-01T23:00:00/2017-12-03T00:00:00"),
             new Period("PT5H"),
@@ -401,7 +401,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularityEqual()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-11-30T23:00:00/2017-12-03T00:00:00"), new Period("P1D")),
         new SegmentGenerateSpec(Intervals.of("2017-10-14T00:00:00/2017-10-15T00:00:00"), new Period("P1D"))
     );
@@ -424,7 +424,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularityLarger()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         // This contains segment that
         // - Cross between month boundary of latest month (starts in Nov and ends in Dec). This should be skipped
         // - Fully in latest month (starts in Dec and ends in Dec). This should be skipped
@@ -454,7 +454,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularitySmaller()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-12-01T23:00:00/2017-12-03T00:00:00"), new Period("PT5H")),
         new SegmentGenerateSpec(Intervals.of("2017-10-14T00:00:00/2017-10-15T00:00:00"), new Period("PT5H"))
     );
@@ -563,7 +563,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsInConfiguredSegmentGranularity()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         // Segments with day interval from Oct to Dec
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-12-31T00:00:00"), new Period("P1D"))
     );
@@ -611,7 +611,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsInMultipleIntervalIfConfiguredSegmentGranularityCrossBoundary()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2020-01-01/2020-01-08"), new Period("P7D")),
         new SegmentGenerateSpec(Intervals.of("2020-01-28/2020-02-03"), new Period("P7D")),
         new SegmentGenerateSpec(Intervals.of("2020-02-08/2020-02-15"), new Period("P7D"))
@@ -648,7 +648,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorDoesNotReturnCompactedInterval()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-12-01T00:00:00/2017-12-02T00:00:00"), new Period("P1D"))
     );
 
@@ -670,7 +670,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsAllMixedVersionSegmentsInConfiguredSegmentGranularity()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"), new Period("P1D"), "1994-04-29T00:00:00.000Z", null),
         new SegmentGenerateSpec(Intervals.of("2017-10-01T01:00:00/2017-10-01T02:00:00"), new Period("PT1H"), "1994-04-30T00:00:00.000Z", null)
     );
@@ -703,7 +703,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -736,7 +736,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -769,7 +769,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -812,7 +812,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -855,7 +855,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -907,7 +907,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -961,7 +961,7 @@ public class NewestSegmentFirstPolicyTest
     // rollup=false for interval 2017-10-01T00:00:00/2017-10-02T00:00:00,
     // rollup=true for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // and rollup=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (queryGranularity was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1021,7 +1021,7 @@ public class NewestSegmentFirstPolicyTest
     // queryGranularity=DAY for interval 2017-10-01T00:00:00/2017-10-02T00:00:00,
     // queryGranularity=MINUTE for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // and queryGranularity=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (queryGranularity was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1082,7 +1082,7 @@ public class NewestSegmentFirstPolicyTest
     // Dimensions=["foo"] for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // Dimensions=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (dimensions was not set during last compaction)
     // and dimensionsSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (dimensionsSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1181,7 +1181,7 @@ public class NewestSegmentFirstPolicyTest
     // filter=SelectorDimFilter("dim1", "bar", null) for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // filter=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (filter was not set during last compaction)
     // and transformSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (transformSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1305,7 +1305,7 @@ public class NewestSegmentFirstPolicyTest
     // metricsSpec={CountAggregatorFactory("cnt"), LongSumAggregatorFactory("val", "val")} for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // metricsSpec=[] for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (filter was not set during last compaction)
     // and metricsSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (transformSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1414,7 +1414,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsSmallerSegmentGranularityCoveringMultipleSegmentsInTimeline()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"), new Period("P1D"), "1994-04-29T00:00:00.000Z", null),
         new SegmentGenerateSpec(Intervals.of("2017-10-01T01:00:00/2017-10-01T02:00:00"), new Period("PT1H"), "1994-04-30T00:00:00.000Z", null)
     );
@@ -1450,7 +1450,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -1497,7 +1497,7 @@ public class NewestSegmentFirstPolicyTest
   {
     NullHandling.initializeForTests();
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1629,9 +1629,7 @@ public class NewestSegmentFirstPolicyTest
     }
   }
 
-  private static VersionedIntervalTimeline<String, DataSegment> createTimeline(
-      SegmentGenerateSpec... specs
-  )
+  private static SegmentTimeline createTimeline(SegmentGenerateSpec... specs)
   {
     List<DataSegment> segments = new ArrayList<>();
     final String version = DateTimes.nowUtc().toString();
@@ -1671,7 +1669,7 @@ public class NewestSegmentFirstPolicyTest
       }
     }
 
-    return VersionedIntervalTimeline.forSegments(segments);
+    return SegmentTimeline.forSegments(segments);
   }
 
   private DataSourceCompactionConfig createCompactionConfig(

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -67,7 +66,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -135,10 +133,6 @@ public class LoadRuleTest
     ));
 
     final DataSegment segment = createDataSegment("foo");
-
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .times(2);
 
     EasyMock.replay(mockPeon, mockBalancerStrategy);
 
@@ -246,10 +240,6 @@ public class LoadRuleTest
 
     final DataSegment segment = createDataSegment("foo");
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .anyTimes();
-
     EasyMock.replay(mockPeon, mockBalancerStrategy);
 
     ImmutableDruidServer server1 =
@@ -293,10 +283,6 @@ public class LoadRuleTest
     ));
 
     final DataSegment segment = createDataSegment("foo");
-
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .anyTimes();
 
     EasyMock.replay(emptyPeon, mockBalancerStrategy);
 
@@ -351,10 +337,6 @@ public class LoadRuleTest
 
     final DataSegment segment = createDataSegment("foo");
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .anyTimes();
-
     EasyMock.replay(emptyPeon, mockBalancerStrategy);
 
     ImmutableDruidServer server1 =
@@ -407,10 +389,6 @@ public class LoadRuleTest
     loadingPeon.loadSegment(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject());
     EasyMock.expectLastCall().once();
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(cachingCostBalancerStrategy)
-            .anyTimes();
-
     EasyMock.replay(loadingPeon, mockBalancerStrategy);
 
     ImmutableDruidServer server =
@@ -441,10 +419,6 @@ public class LoadRuleTest
 
     mockPeon2.loadSegment(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.isNull());
     EasyMock.expectLastCall().once();
-
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .times(2);
 
     EasyMock.replay(mockPeon1, mockPeon2, mockBalancerStrategy);
 
@@ -549,10 +523,6 @@ public class LoadRuleTest
     mockPeon.loadSegment(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject());
     EasyMock.expectLastCall().atLeastOnce();
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .times(1);
-
     EasyMock.replay(mockPeon, mockBalancerStrategy);
 
     LoadRule rule = createLoadRule(ImmutableMap.of("nonExistentTier", 1, "hot", 1));
@@ -613,10 +583,6 @@ public class LoadRuleTest
   @Test
   public void testMaxLoadingQueueSize()
   {
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .times(2);
-
     EasyMock.replay(mockBalancerStrategy);
 
     final LoadQueuePeonTester peon = new LoadQueuePeonTester();
@@ -676,10 +642,6 @@ public class LoadRuleTest
 
     final DataSegment segment = createDataSegment("foo");
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andDelegateTo(balancerStrategy)
-            .times(1);
-
     EasyMock.replay(mockPeon1, mockPeon2, mockBalancerStrategy);
 
     DruidCluster druidCluster = DruidClusterBuilder
@@ -717,10 +679,6 @@ public class LoadRuleTest
     ServerHolder holder3 = createServerHolder("tier2", mockPeon3, false);
     ServerHolder holder4 = createServerHolder("tier2", mockPeon4, false);
 
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(segment, ImmutableList.of(holder2)))
-            .andReturn(Collections.singletonList(holder2).iterator());
-    EasyMock.expect(mockBalancerStrategy.findNewSegmentHomeReplicator(segment, ImmutableList.of(holder4, holder3)))
-            .andReturn(Arrays.asList(holder3, holder4).iterator());
     EasyMock.replay(mockBalancerStrategy);
 
     DruidCluster druidCluster = DruidClusterBuilder

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorDutiesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorDutiesTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.simulate;
+
+import io.vavr.collection.Stream;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.timeline.DataSegment;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CoordinatorDutiesTest extends CoordinatorSimulationBaseTest
+{
+  private final List<DruidServer> servers;
+
+  /**
+   * segments = 10k * 24H (1MB)
+   */
+  private final List<DataSegment> segments =
+      CreateDataSegments.ofDatasource(DS.WIKI)
+                        .forIntervals(24, Granularities.HOUR)
+                        .startingAt("2022-01-01")
+                        .withNumPartitions(10000)
+                        .eachOfSizeInMb(1);
+
+  public CoordinatorDutiesTest()
+  {
+    long startTime = System.currentTimeMillis();
+    servers = createHistoricalTier(Tier.T1, 100, 20000);
+    System.out.println("SETUP TIME: " + (System.currentTimeMillis() - startTime));
+  }
+
+  @Override
+  public void setUp()
+  {
+
+  }
+
+  @Test
+  public void testMarkingThing()
+  {
+    CoordinatorDynamicConfig dynamicConfig =
+        CoordinatorDynamicConfig.builder()
+                                .withMaxSegmentsToMove(0)
+                                .withMaxSegmentsInNodeLoadingQueue(0)
+                                .withLeadingTimeMillisBeforeCanMarkAsUnusedOvershadowedSegments(0)
+                                .build();
+
+    CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withSegments(segments)
+                             .withServers(servers)
+                             .withRules(DS.WIKI, Load.on(Tier.T1, 1).forever())
+                             .withDynamicConfig(dynamicConfig)
+                             .withImmediateSegmentLoading(true)
+                             .withBalancerStrategy("random")
+                             .build();
+
+    // Assign the segments to the servers in a round robin manner
+    // Best way to do it
+    // Run for one cycle with immediate loading
+
+    startSimulation(sim);
+
+    runCoordinatorCycle();
+    printStuff();
+    verifyDatasourceIsFullyLoaded(DS.WIKI);
+
+    //runCoordinatorCycle();
+    //printStuff();
+  }
+
+  private void printStuff()
+  {
+    // System.out.println("assignedCount: " + getValue("segment/assigned/count", null));
+    System.out.printf(
+        "Duty times: %s %s%n, %s %s %s%n %s%n",
+        getDutyTime("duty.LogUsedSegments"),
+        getDutyTime("duty.RunRules"),
+        getAdhocDutyTime("updateReplicasInTier"),
+        getAdhocDutyTime("createSegmentStatus"),
+        getAdhocDutyTime("loadReplicas"),
+        //getAdhocDutyTime("dropReplicas")
+        //getDutyTime("duty.BalanceSegments"),
+        //getDutyTime("duty.MarkAsUnusedOvershadowedSegments"),
+        getDutyTime("DruidCoordinator$UpdateCoordinatorStateAndPrepareCluster")
+        //getDutyTime("duty.UnloadUnusedSegments")
+    );
+    System.out.println(
+        "Historical duties run time: " + getValue(
+            "coordinator/global/time",
+            filter(DruidMetrics.DUTY_GROUP, "HistoricalManagementDuties")
+        )
+    );
+    System.out.println(
+        "Metadata duties run time: " + getValue(
+            "coordinator/global/time",
+            filter(DruidMetrics.DUTY_GROUP, "MetadataStoreManagementDuties")
+        )
+    );
+  }
+
+  private String getDutyTime(String dutyName)
+  {
+    return String.format(
+        "%s [%d]",
+        dutyName,
+        getValue(
+            "coordinator/time",
+            filter(DruidMetrics.DUTY, "org.apache.druid.server.coordinator." + dutyName)
+        ).longValue()
+    );
+  }
+
+  private String getAdhocDutyTime(String dutyName)
+  {
+    return String.format(
+        "%s [%d]",
+        dutyName,
+        getValue(
+            "coordinator/adhoc/time",
+            filter(DruidMetrics.DUTY, dutyName)
+        ).longValue()
+    );
+  }
+
+  private List<DruidServer> createHistoricalTier(String tier, int numServers, long serverSizeMb)
+  {
+    return Stream.range(0, numServers)
+                 .map(serverId -> createHistorical(serverId, tier, serverSizeMb))
+                 .collect(Collectors.toList());
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
@@ -26,6 +26,7 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.common.config.JacksonConfigManager;
 import org.apache.druid.curator.discovery.ServiceAnnouncer;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.DirectExecutorService;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
@@ -40,9 +41,11 @@ import org.apache.druid.server.coordinator.CachingCostBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.CostBalancerStrategyFactory;
+import org.apache.druid.server.coordinator.DiskNormalizedCostBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.LoadQueueTaskMaster;
+import org.apache.druid.server.coordinator.RandomBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.SegmentStateManager;
 import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDutyGroups;
@@ -77,7 +80,7 @@ public class CoordinatorSimulationBuilder
           )
       );
 
-  private BalancerStrategyFactory balancerStrategyFactory;
+  private String balancerStrategy;
   private CoordinatorDynamicConfig dynamicConfig =
       CoordinatorDynamicConfig.builder()
                               .withUseBatchedSegmentSampler(true)
@@ -93,9 +96,9 @@ public class CoordinatorSimulationBuilder
    * <p>
    * Default: "cost" ({@link CostBalancerStrategyFactory})
    */
-  public CoordinatorSimulationBuilder withBalancer(BalancerStrategyFactory strategyFactory)
+  public CoordinatorSimulationBuilder withBalancerStrategy(String strategy)
   {
-    this.balancerStrategyFactory = strategyFactory;
+    this.balancerStrategy = strategy;
     return this;
   }
 
@@ -211,14 +214,33 @@ public class CoordinatorSimulationBuilder
         Collections.emptySet(),
         null,
         new CoordinatorCustomDutyGroups(Collections.emptySet()),
-        balancerStrategyFactory != null ? balancerStrategyFactory
-                                        : new CostBalancerStrategyFactory(),
+        createBalancerStrategy(env),
         env.lookupCoordinatorManager,
         env.leaderSelector,
         OBJECT_MAPPER
     );
 
     return new SimulationImpl(coordinator, env);
+  }
+
+  private BalancerStrategyFactory createBalancerStrategy(Environment env)
+  {
+    if (balancerStrategy == null) {
+      return new CostBalancerStrategyFactory();
+    }
+
+    switch (balancerStrategy) {
+      case "cost":
+        return new CostBalancerStrategyFactory();
+      case "cachingCost":
+        return buildCachingCostBalancerStrategy(env);
+      case "diskNormalized":
+        return new DiskNormalizedCostBalancerStrategyFactory();
+      case "random":
+        return new RandomBalancerStrategyFactory();
+      default:
+        throw new IAE("Unknown balancer stratgy: " + balancerStrategy);
+    }
   }
 
   private BalancerStrategyFactory buildCachingCostBalancerStrategy(Environment env)

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -172,4 +172,37 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     Assert.assertEquals(5, historicalT12.getTotalSegments());
     verifyDatasourceIsFullyLoaded(datasource);
   }
+
+  @Test
+  public void testBalancingMovesSegmentsInLoadQueue()
+  {
+    CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withSegments(segments)
+                             .withServers(historicalT11)
+                             .withRules(datasource, Load.on(Tier.T1, 1).forever())
+                             .build();
+
+    startSimulation(sim);
+
+    // Run 1: All segments are assigned to the first historical
+    runCoordinatorCycle();
+    verifyValue(Metric.ASSIGNED_COUNT, 10L);
+    verifyValue(Metric.LOAD_QUEUE_COUNT, filter(DruidMetrics.SERVER, historicalT11.getName()), 10);
+
+    // Run 2: Add new historical, some segments in the queue will be moved
+    addServer(historicalT12);
+    runCoordinatorCycle();
+    verifyNoEvent(Metric.ASSIGNED_COUNT);
+    verifyValue(Metric.CANCELLED_LOADS, 5L);
+    verifyValue(Metric.MOVED_COUNT, 5L);
+
+    verifyValue(Metric.LOAD_QUEUE_COUNT, filter(DruidMetrics.SERVER, historicalT11.getName()), 5);
+    verifyValue(Metric.LOAD_QUEUE_COUNT, filter(DruidMetrics.SERVER, historicalT12.getName()), 5);
+
+    // Complete loading the segments
+    loadQueuedSegments();
+    Assert.assertEquals(5, historicalT11.getTotalSegments());
+    Assert.assertEquals(5, historicalT12.getTotalSegments());
+  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
@@ -77,7 +77,7 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     startSimulation(sim);
     runCoordinatorCycle();
 
-    // Verify that that replicationThrottleLimit is honored
+    // Verify that the replicationThrottleLimit is honored
     verifyValue(Metric.ASSIGNED_COUNT, 2L);
 
     loadQueuedSegments();

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -146,12 +146,6 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public Set<SegmentId> getOvershadowedSegments()
-  {
-    return getSnapshotOfDataSourcesWithAllUsedSegments().getOvershadowedSegments();
-  }
-
-  @Override
   public DataSourcesSnapshot getSnapshotOfDataSourcesWithAllUsedSegments()
   {
     return DataSourcesSnapshot.fromUsedSegments(usedSegments.values(), ImmutableMap.of());

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -43,16 +43,20 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   private final ConcurrentMap<String, DataSegment> segments = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, DataSegment> usedSegments = new ConcurrentHashMap<>();
 
+  private volatile DataSourcesSnapshot snapshot;
+
   public void addSegment(DataSegment segment)
   {
     segments.put(segment.getId().toString(), segment);
     usedSegments.put(segment.getId().toString(), segment);
+    snapshot = null;
   }
 
   public void removeSegment(DataSegment segment)
   {
     segments.remove(segment.getId().toString());
     usedSegments.remove(segment.getId().toString());
+    snapshot = null;
   }
 
   @Override
@@ -136,7 +140,10 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   @Override
   public ImmutableDruidDataSource getImmutableDataSourceWithUsedSegments(String dataSource)
   {
-    return null;
+    if (snapshot == null) {
+      getSnapshotOfDataSourcesWithAllUsedSegments();
+    }
+    return snapshot.getDataSource(dataSource);
   }
 
   @Override
@@ -148,7 +155,10 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   @Override
   public DataSourcesSnapshot getSnapshotOfDataSourcesWithAllUsedSegments()
   {
-    return DataSourcesSnapshot.fromUsedSegments(usedSegments.values(), ImmutableMap.of());
+    if (snapshot == null) {
+      snapshot = DataSourcesSnapshot.fromUsedSegments(usedSegments.values(), ImmutableMap.of());
+    }
+    return snapshot;
   }
 
   @Override


### PR DESCRIPTION
#### Changes
- Use `RoundRobinServerSelector` to assign segments
- Cost computations are used only for balancing
- Allow segments in loading queue to be considered for balancing