### PR TITLE
Add a new "uniformInterval" balancer strategy

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategy.java
@@ -77,7 +77,7 @@ public interface BalancerStrategy
    * @param broadcastDatasources Segments belonging to these datasources will not
    *                             be picked for balancing, since they should be
    *                             loaded on all servers anyway.
-   * @param reservoirSize        Reservoir size maintained by the sampling algorithm
+   * @param maxSegmentsToPick    Maximum number of segments to pick
    * @param pickLoadingSegments  If true, picks only segments currently being
    *                             loaded on a server. If false, picks segments
    *                             already loaded on a server.
@@ -87,39 +87,16 @@ public interface BalancerStrategy
   default Iterator<BalancerSegmentHolder> pickSegmentsToMove(
       List<ServerHolder> serverHolders,
       Set<String> broadcastDatasources,
-      int reservoirSize,
+      int maxSegmentsToPick,
       boolean pickLoadingSegments
   )
   {
-    return new Iterator<BalancerSegmentHolder>()
-    {
-      private Iterator<BalancerSegmentHolder> it = sample();
-      private Iterator<BalancerSegmentHolder> sample()
-      {
-        return ReservoirSegmentSampler.getRandomBalancerSegmentHolders(
-            serverHolders,
-            broadcastDatasources,
-            reservoirSize,
-            pickLoadingSegments
-        ).iterator();
-      }
-
-      @Override
-      public boolean hasNext()
-      {
-        if (it.hasNext()) {
-          return true;
-        }
-        it = sample();
-        return it.hasNext();
-      }
-
-      @Override
-      public BalancerSegmentHolder next()
-      {
-        return it.next();
-      }
-    };
+    return ReservoirSegmentSampler.getRandomBalancerSegmentHolders(
+        serverHolders,
+        broadcastDatasources,
+        maxSegmentsToPick,
+        pickLoadingSegments
+    ).iterator();
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/UniformIntervalBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/UniformIntervalBalancerStrategy.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.timeline.DataSegment;
+
+import javax.annotation.Nullable;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A balancing strategy that tries to have a uniform number of segments in each
+ * datasource-interval across all servers in a tier.
+ * <p>
+ * The uniform interval strategy may move a segment S of datasource D, interval I
+ * from server A to B only if:
+ * <ol>
+ *   <li>A has atleast 2 more segments in (D,I) than B</li>
+ *   <li>OR, A has exactly 1 more segment in (D,I) than B and
+ *   {@code size(A) - size(B) >= 2 * size(S)}</li>
+ * </ol>
+ * These rules are to ensure that every move takes the cluster closer to a
+ * balanced state and to avoid unnecessary moves, which just result in a
+ * reversal of roles of A and B.
+ * <p>
+ * <b>Principle:</b>
+ * {@link CostBalancerStrategy} works on the principle that segments that are
+ * interval adjacent should be placed on separate servers. This works well when
+ * the number of segments in an interval is smaller than the number of available
+ * servers. But if it is higher (which is very likely the case in practice), some
+ * segments for an interval must be pigeon-holed into a server which already has
+ * a segment for that same interval. This essentially boils down to each server
+ * having a near-equal number of segments for that interval.
+ * <p>
+ * This strategy is thus an over-simplification of the cost strategy.
+ * <p>
+ * <b>Advantages:</b>
+ * <ul>
+ *   <li>Cost computation is much simpler compared to cost strategy, thus
+ *   significantly faster.</li>
+ *   <li>It does not assign higher weight to coarser granularity segments, thus
+ *   cluster is always balanced even if there are a few coarse grain segments (such as ALL).</li>
+ *   <li>It also handles cases where a datasource has only a single segment per
+ *   interval. Cost strategy fails to attain a balanced cluster for such situations.</li>
+ *   <li>Unlike {@link CachingCostBalancerStrategy}, it does not require a cache to
+ *   be initialized. Every {@link ServerHolder} created at the start of a coordinator
+ *   run is initialized with the segment count in each datasource-interval.</li>
+ * </ul>
+ * <p>
+ * <b>Assumptions:</b>
+ * <ul>
+ *   <li>All segments in a given datasource-interval are nearly of the same size.</li>
+ *   <li>All servers in a tier have the same disk capacity. (This can be remedied
+ *   in later versions by computing percentages in Rule 2 rather than absolute sizes.)</li>
+ * </ul>
+ */
+public class UniformIntervalBalancerStrategy implements BalancerStrategy
+{
+
+  /**
+   * Orders servers first by number of segments in datasource interval (lowest first)
+   * and then by used percentage (lowest first).
+   */
+  private static final Comparator<ServerSegmentCount> CHEAPEST_SERVERS_FIRST
+      = Comparator.<ServerSegmentCount>comparingInt(entry -> entry.segmentCount)
+      .thenComparingDouble(entry -> entry.server.getPercentUsed())
+      .thenComparingInt(entry -> ThreadLocalRandom.current().nextInt());
+
+  @Nullable
+  @Override
+  public ServerHolder findDestinationServerToMoveSegment(
+      DataSegment segment,
+      ServerHolder sourceServer,
+      List<ServerHolder> destinationServers
+  )
+  {
+    Iterator<ServerHolder> bestServers = chooseBestServers(segment, destinationServers, true);
+    if (!bestServers.hasNext()) {
+      return null;
+    }
+
+    ServerHolder targetServer = bestServers.next();
+    final int countOnSource = sourceServer.getNumSegmentsInDatasourceInterval(segment);
+    final int countOnTarget = targetServer.getNumSegmentsInDatasourceInterval(segment);
+
+    // Avoid unnecessary moves that do not lead to balance and would only result
+    // in a reversal of roles of source and target
+    if (countOnSource - countOnTarget >= 2) {
+      return targetServer;
+    } else if (countOnSource - countOnTarget == 1
+               && (sourceServer.getSizeUsed() - targetServer.getSizeUsed() >= 2 * segment.getSize())) {
+      return targetServer;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Iterator<ServerHolder> findServerToLoadSegment(
+      DataSegment proposalSegment,
+      List<ServerHolder> serverHolders
+  )
+  {
+    return chooseBestServers(proposalSegment, serverHolders, false);
+  }
+
+  @Override
+  public void emitStats(String tier, CoordinatorRunStats stats, List<ServerHolder> serverHolderList)
+  {
+    // Do not emit anything
+  }
+
+  private Iterator<ServerHolder> chooseBestServers(
+      final DataSegment proposalSegment,
+      final Iterable<ServerHolder> serverHolders,
+      final boolean includeCurrentServer
+  )
+  {
+    final PriorityQueue<ServerSegmentCount> costPrioritizedServers =
+        new PriorityQueue<>(CHEAPEST_SERVERS_FIRST);
+
+    for (ServerHolder server : serverHolders) {
+      final int count = server.getNumSegmentsInDatasourceInterval(proposalSegment);
+      if (includeCurrentServer || server.canLoadSegment(proposalSegment)) {
+        costPrioritizedServers.add(new ServerSegmentCount(server, count));
+      }
+    }
+
+    // Include current server only if specified
+    return costPrioritizedServers.stream()
+                                 .filter(entry -> includeCurrentServer
+                                                  || entry.server.canLoadSegment(proposalSegment))
+                                 .map(entry -> entry.server).iterator();
+  }
+
+  private static class ServerSegmentCount
+  {
+    private final int segmentCount;
+    private final ServerHolder server;
+
+    private ServerSegmentCount(ServerHolder server, int segmentCount)
+    {
+      this.server = server;
+      this.segmentCount = segmentCount;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/UniformIntervalBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/UniformIntervalBalancerStrategyFactory.java
@@ -19,19 +19,18 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "strategy", defaultImpl = CostBalancerStrategyFactory.class)
-@JsonSubTypes(value = {
-        @JsonSubTypes.Type(name = "diskNormalized", value = DiskNormalizedCostBalancerStrategyFactory.class),
-        @JsonSubTypes.Type(name = "cost", value = CostBalancerStrategyFactory.class),
-        @JsonSubTypes.Type(name = "cachingCost", value = CachingCostBalancerStrategyFactory.class),
-        @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class),
-        @JsonSubTypes.Type(name = "uniformInterval", value = UniformIntervalBalancerStrategyFactory.class)
-})
-public interface BalancerStrategyFactory
+/**
+ * Factory for {@link UniformIntervalBalancerStrategy}.
+ */
+public class UniformIntervalBalancerStrategyFactory implements BalancerStrategyFactory
 {
-  BalancerStrategy createBalancerStrategy(ListeningExecutorService exec);
+
+  @Override
+  public BalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
+  {
+    return new UniformIntervalBalancerStrategy();
+  }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-package org.apache.druid.server.coordinator;
+package org.apache.druid.server.coordinator.balancer;
 
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.server.coordination.ServerType;
-import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
-import org.apache.druid.server.coordinator.balancer.CostBalancerStrategy;
-import org.apache.druid.server.coordinator.balancer.RandomBalancerStrategy;
+import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.loadqueue.LoadQueuePeonTester;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
@@ -46,6 +46,7 @@ import org.apache.druid.server.coordinator.balancer.CachingCostBalancerStrategyF
 import org.apache.druid.server.coordinator.balancer.CostBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.balancer.DiskNormalizedCostBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.balancer.RandomBalancerStrategyFactory;
+import org.apache.druid.server.coordinator.balancer.UniformIntervalBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.duty.CompactionSegmentSearchPolicy;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDutyGroups;
 import org.apache.druid.server.coordinator.duty.NewestSegmentFirstPolicy;
@@ -224,7 +225,7 @@ public class CoordinatorSimulationBuilder
   private BalancerStrategyFactory createBalancerStrategy(Environment env)
   {
     if (balancerStrategy == null) {
-      return new CostBalancerStrategyFactory();
+      return new UniformIntervalBalancerStrategyFactory();
     }
 
     switch (balancerStrategy) {
@@ -236,6 +237,8 @@ public class CoordinatorSimulationBuilder
         return new DiskNormalizedCostBalancerStrategyFactory();
       case "random":
         return new RandomBalancerStrategyFactory();
+      case "uniformInterval":
+        return new UniformIntervalBalancerStrategyFactory();
       default:
         throw new IAE("Unknown balancer stratgy: " + balancerStrategy);
     }


### PR DESCRIPTION
## Description

A balancing strategy that tries to have a uniform number of segments in each
datasource-interval across all servers in a tier.

### Movement rules
The "uniformInterval" strategy moves a segment S of datasource D, interval I from server A to B if and only if:
- A has atleast 2 more segments in (D,I) than B
- OR, A has exactly 1 more segment in (D,I) than B and `diskUsage(A) - diskUsage(B) >= 2*size(S)`

These rules are explained in the [design here](#uniform-design).

> ⚠️⚠️ Work in progress: There are certain cases where these rules can lead to a bit of skew, primarily because of the remainder segments that couldn't be divided equally amongst all servers. To assign the remainder segments uniformly, the rules are being refined further to take into account disk usage per datasource per interval bucket.

### Assumptions
- All segments in a given datasource-interval are nearly of the same size. (much better than assuming that all segments of all datasources and all intervals are of the same size).
- All servers in a tier have the same disk capacity. (This can be remedied in later versions by computing percentages in Rule 2 rather than absolute sizes.)

## Changes
- Add new "uniformInterval" strategy
- Make this the new default for all coordinator simulation tests

## Motivation
Segment balancing has 2 main goals:
1. Queries should make optimal use of historical compute power
⇒ Segments that are likely to be queried together are kept on different servers
⇒ Segments that are interval-adjacent are kept on different servers
2. All historicals should have similar levels of disk and memory usage.

"cost" balancer strategy works on principle 1 (and generally gets 2 as an added benefit) i.e. segments that are interval adjacent should be placed on separate servers. This works well when the number of segments in an interval is smaller than the number of available servers. But if it is higher (which is very likely the case in practice), some segments for the interval must be pigeon-holed into a server which already has 1 or more segments for that same interval. In such cases, "cost" strategy goes through heavy computations but the end result essentially boils down to each server having a near-equal number of segments for that interval.

This strategy is meant to be an (over-)simplification of the cost strategy.

## <a name='uniform-design' href='#uniform-design'>#</a> Design
- The "uniformInterval" strategy is straightforward if the number of segments in an interval is perfectly divisible by the number of servers. But if that is not the case, the remainder segments are placed on the server with most free space available.
- The two rules used by the strategy are to ensure that every move takes the cluster closer to a balanced state and to avoid unnecessary moves, which just result in a reversal of roles of A and B.
- **Rule 1: Move S from A to B if A has at least 2 more segments than B in (D, I)**.
  - If A has only 1 more segment than B in (D,I), moving S would reverse roles of A and B making the segment eligible for move from B to A in the next iteration. The exception to this scenario is Rule 2.
  - If A has the same number as B in (D,I), no move should be done even when there is a large difference in disk usage between A and B. This is because the difference in disk usage is probably stemming from a skew of some other datasource-interval and we should allow segments of that datasource-interval to remedy the problem rather than this segment.
  - If A has less segments than B in (D, I), then moving would only cause more imbalance.
- **Rule 2: Move S from A to B if A has exactly 1 more segment than B in (D,I) and `diskUsage(A) - diskUsage(B) >= 2*size(S)`**
  - If we do not move in this case, cluster can end up in large imbalance. For every datasource-interval, `total segments in (D,I) % num_servers` would not participate in balancing at all causing unequal disk usages.
  - The disk usage condition again ensures that the roles of the two servers are not reversed in the next iteration.

## Advantages
- Attains a better and quicker balance than "cost". It can be easily proved with simulations that a cluster balanced with "uniformInterval" will not be balanced further by "cost".
- Balancing computation is much simpler compared to cost strategy, thus significantly faster. The coordinator can comfortably make move decisions for 100k segments in each run (in under 5s).
("cost" typically takes 5 to 10 mins to perform computations for 1k segments)
- It does not assign higher weight to coarser granularity segments, thus the cluster is always balanced even if there are a few coarse grain segments (such as ALL).
- It also handles cases where a datasource has only a single segment per interval. "cost" strategy fails to attain a balanced cluster for such situations. (see newly added test)
- Unlike "cachingCost" strategy, it does not require a cache to be initialized. Every `ServerHolder` created at the start of a coordinator run is initialized with the segment count in each datasource-interval.
- It is much easier to reason about and measure current level of imbalance (metric to be added).

## Testing
- Perf simulations: Using `CoordinatorSimulation`, this strategy was able to do a full coordinator run of historical management duties (RunRules, BalanceSegments etc) of:
  - 100K segments in under 6s
  - 1M segments in under 10 minutes (didn't grow linearly due to limited resources on the local machine)
- Unit tests: This strategy works with all the simulation tests and is the new default in simulations.
- Cluster testing.
  - Setup: 1 master node m5.2xlarge (8vCPU, 32g), 5 historicals m5d.2xlarge (8vCPU, 32g)
  - Configs: maxSegmentInNodeLoadingQueue=0, maxSegmentsToMove=100k, useRoundRobinSegmentAssignment=false
  - Assigned 1M segments under 10s
  - Moved a few segments around, then stabilized

## Additional work
The level of skew in any datasource-interval could be used to prioritize sampling and movement of segments in that interval. But given that we are able to move a large number of segments in one go, we probably wouldn't need a prioritized sampling after all.